### PR TITLE
feat: Random background generation

### DIFF
--- a/generator/traits.example.py
+++ b/generator/traits.example.py
@@ -39,12 +39,14 @@ layers = [
     {   # Background color
         "layer_name": "Background color",
         "rgba": {
-            "Black": (  0,   0,   0, 255)
+            # Uncomment Black for black background
+            # "Black":       (  0,   0,   0, 255),
+            "Transparent": (  0,   0,   0,   0),
         },
         "weights": [
             100
         ],
-        "size": (640, 640)
+        "size": (640, 640)  # Adjust to the size of your images
     },
     {   # layer01
         "layer_name": "Pretty Trait Name 01",

--- a/generator/traits.example.py
+++ b/generator/traits.example.py
@@ -36,6 +36,16 @@ COLLECTION_NAME="Collection Name"
 
 ## Layers dictionary
 layers = [
+    {   # Background color
+        "layer_name": "Background color",
+        "rgba": {
+            "Black": (  0,   0,   0, 255)
+        },
+        "weights": [
+            100
+        ],
+        "size": (640, 640)
+    },
     {   # layer01
         "layer_name": "Pretty Trait Name 01",
         "filenames": {

--- a/generator/traits.example.py
+++ b/generator/traits.example.py
@@ -75,5 +75,5 @@ layers = [
 def get_variation_cnt():
     cnt = 1
     for l in layers:
-        cnt *= len(l["filenames"])
+        cnt *= len(l["weights"])
     return cnt


### PR DESCRIPTION
Adds ability to pick background color or transparent background.
Can also add a set of colors and weights for random generation.
Example with random red/green/blue color:
```python
## Layers dictionary
layers = [
    {   # Background color
        "layer_name": "Background color",
        "rgba": {
            "Red":   (192,  54,  54, 255),
            "Green": ( 54, 192,  54, 255),
            "Blue":  ( 54,  54, 192, 255),
        },
        "weights": [
            33,
            33,
            34
        ],
        "size": (640, 640)  # Adjust to the size of your images
    },
    {   # layer01
        "layer_name": "Pretty Trait Name 01",
        "filenames": {
            "Pretty Item Name 01": "item_01.png",
            "Pretty Item Name 02": "item_02.png"
        },
        "weights": [
            50,
            50
        ]
    },
    {   # layer02
        "layer_name": "Pretty Trait Name 02",
        "filenames": {
            "Pretty Item Name 01": "item_01.png",
            "Pretty Item Name 02": "item_02.png"
        },
        "weights": [
            50,
            50
        ]
    }
]

```